### PR TITLE
Update output if SNAP_PAC_SKIP variable is used

### DIFF
--- a/grub-mkconfig
+++ b/grub-mkconfig
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
-[[ -v SNAP_PAC_SKIP ]] && { printf "==> skipping due to SNAP_PAC_SKIP being set"; exit 0; }
+case $SNAP_PAC_SKIP in
+  y|yes|true|1)
+    printf "snapper snapshots skipped"
+    exit 0
+    ;;
+esac
 
 /usr/bin/grub-mkconfig -o /boot/grub/grub.cfg


### PR DESCRIPTION
The snap-pac script /usr/share/libalpm/scripts/snap-pac (before Bash and now Python) checks the value of the vairable and uses a different output.

```
def check_skip():
     return os.getenv("SNAP_PAC_SKIP", "n").lower() in ["y", "yes", "true", "1"]

if check_skip():
         logging.warning("snapper snapshots skipped")
         quit()
```

PS. Please update the commit message