### PR TITLE
Rename description in hook to match other hooks

### DIFF
--- a/zz-snap-pac-grub-post.hook
+++ b/zz-snap-pac-grub-post.hook
@@ -6,7 +6,7 @@ Type = Package
 Target = *
 
 [Action]
-Description = Generate GRUB config to let grub-btrfs detect new snapshots
+Description = Generating GRUB config to let grub-btrfs detect new snapshots...
 Depends = grub
 When = PostTransaction
 Exec = /usr/share/libalpm/scripts/grub-mkconfig


### PR DESCRIPTION
Other hooks use `-ing` and `...`

Only cosmetic. Just saw this while I created a hook documentation. 