### PR TITLE
Feature: Run grub-mkconfig in background and redirect output to system log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# snap-pac-grub
+
+This script is intended to be used as a Pacman hook for regenerating the GRUB config after updates, in systems using snapper and grub-btrfs.
+
+## Configuration
+
+Two optional environment variables control the behavior:
+
+### `SNAP_PAC_SKIP`
+Skip the script entirely. Use this to disable snapshot-related GRUB updates when not needed.
+
+Values that cause it to skip:
+
+* `y, yes, true, 1`
+
+### `SNAP_PAC_GRUB_ASYNC`
+By default, grub-mkconfig can take some time to complete. This script supports an asynchronous mode, allowing it to run in the background and send output to the system log. This makes Pacman operations faster, while still preserving a log of GRUB config generation in case you want to inspect it later.
+
+You can then inspect the output using:
+```bash
+journalctl -t grub-mkconfig
+```
+
+Values that enable async mode:
+
+* `y, yes, true, 1`
+
+
+
+### Example `.bashrc` / `.zshrc` / ...
+
+```bash
+export SNAP_PAC_GRUB_ASYNC=1
+```

--- a/grub-mkconfig
+++ b/grub-mkconfig
@@ -2,10 +2,16 @@
 
 case $SNAP_PAC_SKIP in
   y|yes|true|1)
-    printf "snapper snapshots skipped"
+    printf "snapper snapshots skipped\n"
     exit 0
     ;;
 esac
 
-/usr/bin/nohup bash -c '/usr/bin/grub-mkconfig -o /boot/grub/grub.cfg 2>&1 | logger -t grub-mkconfig' >/dev/null 2>&1 &
+case $SNAP_PAC_GRUB_ASYNC in
+  y|yes|true|1)
+    /usr/bin/nohup bash -c '/usr/bin/grub-mkconfig -o /boot/grub/grub.cfg 2>&1 | logger -t grub-mkconfig' >/dev/null 2>&1 &
+    exit 0
+    ;;
+esac
 
+/usr/bin/grub-mkconfig -o /boot/grub/grub.cfg

--- a/grub-mkconfig
+++ b/grub-mkconfig
@@ -7,4 +7,5 @@ case $SNAP_PAC_SKIP in
     ;;
 esac
 
-/usr/bin/grub-mkconfig -o /boot/grub/grub.cfg
+/usr/bin/nohup bash -c '/usr/bin/grub-mkconfig -o /boot/grub/grub.cfg 2>&1 | logger -t grub-mkconfig' >/dev/null 2>&1 &
+


### PR DESCRIPTION
This PR modifies the execution of `grub-mkconfig` to run in the background and redirect its output to the system log.
Instead of blocking execution, this allows the command to run asynchronously and still provides a way to view its logs later using `journalctl`.
Doing it this way you don't need to wait for `grub-mkconfig` to finish executing every time we use pacman, while still providing a way to see the output in case something fails.

The hook's full stdout now becomes:
`(5/5) Generating GRUB config to let grub-btrfs detect new snapshots...`

It's still possible to see `grub-mkconfig` logs using:
`$ journalctl -t grub-mkconfig`

Would you be okay with this behavior change, or would you prefer it to be configurable (e.g., an option to choose between synchronous and asynchronous execution)?
I’m happy to adjust the PR if a more flexible or configurable approach is preferred!

Thanks for your time and for maintaining this project 🙏